### PR TITLE
Implementing From/Into

### DIFF
--- a/src/mt/header.rs
+++ b/src/mt/header.rs
@@ -326,6 +326,11 @@ impl Header {
     fn disposition_flags(self) -> DispositionFlags {
         self.disposition_flags
     }
+
+    #[allow(dead_code)]
+    pub(crate) fn builder() -> HeaderBuilder {
+        HeaderBuilder::default()
+    }
 }
 
 // Let's allow dead while still WIP

--- a/src/mt/mod.rs
+++ b/src/mt/mod.rs
@@ -128,6 +128,28 @@ mod test_mt_information_element {
     }
 }
 
+impl From<Header> for InformationElement {
+    fn from(header: Header) -> Self {
+        InformationElement::H(header)
+    }
+}
+
+#[cfg(test)]
+mod test_mt_information_element_from {
+    use crate::mt::{Header, InformationElement, InformationElementTemplate};
+
+    #[test]
+    fn header() {
+        let header = Header::builder()
+            .client_msg_id(9999)
+            .imei([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4])
+            .build()
+            .unwrap();
+        let ie = InformationElement::from(header);
+        assert!(ie.identifier() == 0x41);
+    }
+}
+
 #[derive(Debug)]
 pub struct MTMessage {
     elements: Vec<InformationElement>,

--- a/src/mt/mod.rs
+++ b/src/mt/mod.rs
@@ -128,15 +128,27 @@ mod test_mt_information_element {
     }
 }
 
+impl From<Confirmation> for InformationElement {
+    fn from(confirmation: Confirmation) -> Self {
+        InformationElement::C(confirmation)
+    }
+}
+
 impl From<Header> for InformationElement {
     fn from(header: Header) -> Self {
         InformationElement::H(header)
     }
 }
 
+impl From<Payload> for InformationElement {
+    fn from(payload: Payload) -> Self {
+        InformationElement::P(payload)
+    }
+}
+
 #[cfg(test)]
 mod test_mt_information_element_from {
-    use crate::mt::{Header, InformationElement, InformationElementTemplate};
+    use crate::mt::{Header, InformationElement, InformationElementTemplate, Payload};
 
     #[test]
     fn header() {
@@ -147,6 +159,13 @@ mod test_mt_information_element_from {
             .unwrap();
         let ie = InformationElement::from(header);
         assert!(ie.identifier() == 0x41);
+    }
+
+    #[test]
+    fn payload() {
+        let payload = Payload::builder().payload("Hey, it's me!").build().unwrap();
+        let ie = InformationElement::from(payload);
+        assert!(ie.identifier() == 0x42);
     }
 }
 

--- a/src/mt/payload.rs
+++ b/src/mt/payload.rs
@@ -71,6 +71,10 @@ impl Payload {
             Ok(Payload { payload })
         }
     }
+    #[allow(dead_code)]
+    pub(crate) fn builder() -> PayloadBuilder {
+        PayloadBuilder::default()
+    }
 }
 
 impl PayloadBuilder {


### PR DESCRIPTION
Simplify the transition from information elements to a message.

`msg.push(Header::builder()....into())`
or
`Header::try_from(msg)`

@luizirber , what do you think?